### PR TITLE
Fix "clarity" section

### DIFF
--- a/draft-haberman-iasa20dt-recs-01.xml
+++ b/draft-haberman-iasa20dt-recs-01.xml
@@ -505,8 +505,11 @@
             of IASA staff.</t>
             <t>Re-structure the internal IETF organization and appointment processes
             for the IAOC to address current challenges. IETF Trust to be kept separate from IAOC.</t>
-            <t>Establish IETF community consensus about who has policy authority for
-            administrative decisions where there is currently a lack of clarity.</t>
+            <t>Drive IETF community consensus on roles and responsibilities for administrative 
+		    decision-making so it is completely clear what people or group has authority 
+		    to make decisions, and what type of consultation, if any, should take place with 
+		    the community in advance so as to eliminate the current lack of clarity and friction 
+		    that exists today.</t>
 	  </list></t>
 
           <t>The key focus in implementing this option would be sorting out the roles


### PR DESCRIPTION
- Which ones would these be: "Establish IETF community consensus about who has policy authority for administrative decisions where there is currently a lack of  clarity." Can we be more specific?
    
    Ouch, that is very abstract.
    
[JL] Alternative to consider:
“Drive IETF community consensus on roles and responsibilities for administrative decision-making so it is completely clear what people or group has authority to make decisions, and what type of consultation, if any, should take place with the community