### PR TITLE
3.1.1.,  3.1.2., 3.1.3. changes proposed by Leslie

### DIFF
--- a/draft-haberman-iasa20dt-recs-01.xml
+++ b/draft-haberman-iasa20dt-recs-01.xml
@@ -245,6 +245,11 @@
 	    also functions as important as fundraising and sponsorship
 	    development can suffer from a lack of clear
 	    responsibility.</t>
+		  
+	    <t>IETFAdminOrg must have lines of responsibility that are 
+		    clear enough for non-IETFers to understand where 
+		    responsibilities lie, and how to make changes as 
+		    necessary over time.</t>
 
 	  </section>
 
@@ -265,6 +270,12 @@
 	      <t>can result in those soliciting sponsorships and
 	      donations having a lack of familiarity with IETF
 	      work.</t>
+	      <t>IETFAminOrg must have an integrated and 
+		      understandable representation mode.  
+		      People not familiar with the IETF 
+		      (e.g., potential sponsors) must be able 
+		      to recognize when or how an entity speaks 
+		      for the IETF.</t>
 	    </list>
 	    </t>
 	  </section>
@@ -286,6 +297,12 @@
 	    agreement with the software provider. Ideally, IETF could
 	    make decisions free from operational and other constraints
 	    imposed by its relationship with ISOC.</t>
+		  
+	   <t>IETFAdminOrg must have enough and appropriate authority 
+		   to carry out the IETF’s administrative requirements 
+		   and activities in a timely fashion, and as the IETF 
+		   desires (within reason of normal business and legal 
+		   requirements).</t>
 	  </section>
 
 	  <section title="Oversight">


### PR DESCRIPTION
3.1.1.  Responsibility

   The line between the IETF and ISOC is not organizationally clear-cut,
   which has led to issues around transparency, allocation of staff time
   and priorities, budgeting, and clarity of who is responsible for
   what.

   Often, in can be unclear what part of the IETF or ISOC is responsible
   for a particular function.  Things as simple as ensuring there is a
   lanyard sponsor/coordinator, but also functions as important as
   fundraising and sponsorship development can suffer from a lack of
   clear responsibility.

LLD:  Add

IETFAdminOrg must have lines of responsibility that are clear enough for non-IETFers to understand where responsibilities lie, and how to make changes as necessary over time.


3.1.2.  Representation

   The respective roles of ISOC, the IETF chair, the IAOC, and the
   secretariat in representing the IETF to sponsors and donors and
   communicating with them are not clear.

   Having ISOC represent the IETF to sponsors and donors:

   o  creates confusion about why the IETF does not represent itself,

   o  yields questions about why ISOC does not instead increase its IETF
      support and how donations can be guaranteed to be dedicated to the
      IETF, and

   o  can result in those soliciting sponsorships and donations having a
      lack of familiarity with IETF work.



LLD:  Add

IETFAminOrg must have an integrated and understandable representation mode.  People not familiar with the IETF (e.g., potential sponsors) must be able to recognize when or how an entity speaks for the IETF.

3.1.3.  Authority

   Another significant problem concerns authority, and to what extent
   can IETF make decisions on its own in the current structure compared
   to decisions that require ISOC approval and agreement.

   Example: Due to IETF's lack of legal status, contractual agreements
   must be signed by ISOC on behalf of the IETF.  There are occasions
   when a decision that is right for the IETF and desired by IETF
   leadership cannot be executed due to constraints posed by what ISOC
   can and cannot agree to itself.  For example, when IETF sought to
   acquire a recent piece of software for business purposes, ISOC would
   initially not agree to entering into an agreement with the software
   provider.  Ideally, IETF could make decisions free from operational
   and other constraints imposed by its relationship with ISOC.


LLD:  Add

IETFAdminOrg must have enough and appropriate authority to carry out the IETF’s administrative requirements and activities in a timely fashion, and as the IETF desires (within reason of normal business and legal requirements).