### PR TITLE
Leslie's 5.1.1 proposed change

### DIFF
--- a/draft-haberman-iasa20dt-recs-01.xml
+++ b/draft-haberman-iasa20dt-recs-01.xml
@@ -483,7 +483,7 @@
       <section anchor="overallstructure" title="Overall Structure">
 
         <section title="IASA++">
-          <t>In the IASA++ option, IETFAminOrg is implemented again as an activity within 
+          <t>In the IASA++ option, IETFAminOrg continues to be implemented as an activity within 
 		  ISOC.   While addressing the requirements above, this does mean that 
 		  ISOC maintains funds and contracting authority on behalf of the IETF, 
 		  and all IASA staff are ISOC employees.</t>

--- a/draft-haberman-iasa20dt-recs-01.xml
+++ b/draft-haberman-iasa20dt-recs-01.xml
@@ -483,11 +483,10 @@
       <section anchor="overallstructure" title="Overall Structure">
 
         <section title="IASA++">
-          <t>In the IASA++ option, the IETF and ISOC maintain the current structural
-          relationship.  This means that the IETF remains an organized activity of
-          ISOC, ISOC maintains funds and contracting authority on behalf of the
-          IETF, and all IASA staff are ISOC employees. In essence, this is today's model
-	  with very minor improvements.</t>
+          <t>In the IASA++ option, IETFAminOrg is implemented again as an activity within 
+		  ISOC.   While addressing the requirements above, this does mean that 
+		  ISOC maintains funds and contracting authority on behalf of the IETF, 
+		  and all IASA staff are ISOC employees.</t>
 
           <t>While the relationship remains the same, the IETF and ISOC will make
           improvements to the relationship in order to enhance the functionality of the


### PR DESCRIPTION
5.1.1.  IASA++

LLD:  Change this:

   In the IASA++ option, the IETF and ISOC maintain the current
   structural relationship.  This means that the IETF remains an
   organized activity of ISOC, ISOC maintains funds and contracting
   authority on behalf of the IETF, and all IASA staff are ISOC
   employees.  In essence, this is today's model with very minor
   improvements.

LLD: to this:

In the IASA++ option, IETFAminOrg is implemented again as an activity within ISOC.   While addressing the requirements above, this does mean that ISOC maintains funds and contracting authority on behalf of the IETF, and all IASA staff are ISOC employees.